### PR TITLE
Changed requirements.txt because I got a config error on psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,5 @@ greenlet~=1.1.0
 gunicorn~=20.1.0
 setuptools~=49.2.1
 attrs~=20.3.0
-psycopg2~=2.8.6
+#psycopg2~=2.8.6 # I got error messages when trying to install this
+psycopg2-binary # They suggest using this for most systems: https://www.psycopg.org/docs/install.html


### PR DESCRIPTION
The nice people at psycopg2 suggest using the precompiled binary for most systems instead of building from source: https://www.psycopg.org/docs/install.html